### PR TITLE
Fix runetimezilla (part of the Bottles runtime fix effort)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PyYAML==5.4.1
+PyYAML==6.0.1
 schema==0.7.5

--- a/runtimezillalib/builder.py
+++ b/runtimezillalib/builder.py
@@ -90,7 +90,7 @@ class Builder:
     
     def copy_to_runtime(self, file: str):
         files = self.search_in_system(file)
-        if not file:
+        if not files:
             log([f"{file} not found in current system, skipping"])
             return False
                 


### PR DESCRIPTION
Part of the Bottles runtime fix effort, see https://github.com/bottlesdevs/Bottles/issues/3054.

This PR is needed by (and blocks):
- https://github.com/bottlesdevs/build-tools/pull/6

:warning:  Please tag and release a `0.2` version upon merging so that [build-tools](https://github.com/bottlesdevs/build-tools/blob/c0dae7673df897fd38d51c72741ea33e74e5b5fc/runtime/environment.sh#L53-L58) can pick the fixed version!